### PR TITLE
Fix weapon selection showing untranslated weapon name

### DIFF
--- a/plugins/wepselect.lua
+++ b/plugins/wepselect.lua
@@ -72,7 +72,7 @@ if (CLIENT) then
 				end
 
 				surface.SetFont("ixWeaponSelectFont")
-				local weaponName = weapons[i]:GetPrintName():utf8upper()
+				local weaponName = language.GetPhrase(weapons[i]:GetPrintName()):utf8upper()
 				local _, ty = surface.GetTextSize(weaponName)
 				local scale = 1 - math.abs(theta * 2)
 


### PR DESCRIPTION
## 🚨 Oops, this PR is for the wrong repo, wanted to make the PR upstream

This fixes the weapon selection showing #GMOD_TOOL instead of TOOL GUN. 

Before this PR:
<img width="933" height="517" alt="afbeelding" src="https://github.com/user-attachments/assets/c2fc07c9-f24e-4e1a-8331-29b212f82ae6" />

After:
<img width="1171" height="565" alt="after" src="https://github.com/user-attachments/assets/00ce3d25-0791-48bb-9edb-c476337bfe24" />

This will also work for all other Lua defined weapons that have their `.PrintName` set as a translatable string. The [wiki explicitly mentions using `language.GetPhrase`](https://wiki.facepunch.com/gmod/Weapon:GetPrintName) with `GetPrintName` as this PR now implements.